### PR TITLE
Allows embedding of twitter links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,8 @@
 
     <title>Youth in front</title>
 
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+
     <!-- Bootstrap core CSS -->
     <link href="{{site.baseurl}}/css/bootstrap.min.css" rel="stylesheet">
 
@@ -16,7 +18,6 @@
     <link href="{{site.baseurl}}/css/album.css" rel="stylesheet">
     <link href="{{site.baseurl}}/css/yif.css" rel="stylesheet">
     <link href="{{site.baseurl}}/css/fontawesome-all.min.css" rel="stylesheet">
-
   </head>
 
   <body>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -16,3 +16,5 @@ layout: default
         {{ content }}
     </div>
 </div>
+
+<script src="{{site.baseurl}}/js/tweet.js" type="text/javascript" />

--- a/js/tweet-example.md
+++ b/js/tweet-example.md
@@ -1,0 +1,6 @@
+Hello
+======
+
+[Tweet](https://twitter.com/Interior/status/970824356476735493)
+
+Is a tweet

--- a/js/tweet.js
+++ b/js/tweet.js
@@ -1,0 +1,29 @@
+(function(){
+    function fixTweets() {
+        var elements = document.getElementsByTagName("a");
+        for(var i = 0; i < elements.length; i++) {
+            var element = elements[i];
+            var link = element.href;
+            if (link.indexOf("twitter.com") != -1) {
+                loadTweet(link, element, function(element, data) {
+                    console.log(data);
+                    element.innerHTML = data.html;
+                });
+            }
+        }
+    }
+
+    function loadTweet(link, element, callback) {
+        var url = "https://api.twitter.com/1/statuses/oembed.json?url="+link;
+        $.ajax({
+            url: url,
+            dataType: "jsonp",
+            success: function(data){
+                console.log(data);
+                callback(element, data);
+            }
+        });
+    }
+
+    fixTweets();
+})();

--- a/tweet-example.md
+++ b/tweet-example.md
@@ -1,0 +1,9 @@
+---
+layout: page
+---
+
+Hello
+======
+
+
+[Tweet](https://twitter.com/Interior/status/970824356476735493)


### PR DESCRIPTION
A somewhat hacky means of making twitter links work.

Pages embed a js file that scans all links for links out to twitter, then fetches tweet data via ajax and embeds it.

I did everything until the cross-site call without jQuery, but I couldn't figure out how to make jsonp work correctly on my own. This could obviously be improved by using jQuery selectors instead of my bullshit. 

If this looks acceptably hacky, lets merge it in and let folks embed tweets?